### PR TITLE
Changing one line in report.py so that only json files are used

### DIFF
--- a/tests/report.py
+++ b/tests/report.py
@@ -74,7 +74,8 @@ def gen_report():
         for backend in ["pyciemss", "sciml"]:
             path = f"scenarios/{scenario}/{backend}"
             if os.path.exists(path):
-                scenario_spec[backend] = os.listdir(f"scenarios/{scenario}/{backend}")
+                scenario_spec[backend] = [f for f in os.listdir(f"scenarios/{scenario}/{backend}")
+                                          if f.endswith(".json")] # only grab json files (ignore hidden notebooks)
         for service_name, tests in scenario_spec.items():
             for test_file in tests:
                 test = test_file.split(".")[0]


### PR DESCRIPTION
This small PR changes one line in `tests/report.py` so that only json files are used in scenarios, and hidden notebooks are ignored.

Closes #41 